### PR TITLE
[FIX] create secret set replication-policy=automatic

### DIFF
--- a/gcloud-manager/src/main/java/core/infra/gcloud/SecretClient.java
+++ b/gcloud-manager/src/main/java/core/infra/gcloud/SecretClient.java
@@ -25,7 +25,7 @@ public class SecretClient {
     }
 
     private void createSecret(String project, String secret) {
-        Shell.Result result = Shell.execute("gcloud", "--project=" + project, "secrets", "create", secret, "--format=json");
+        Shell.Result result = Shell.execute("gcloud", "--project=" + project, "secrets", "create", secret, "--format=json", "--replication-policy=automatic");
         if (result.success() || result.error.contains("already exists")) return;
         throw new Error("failed to create secret, secret=" + secret + ", error=" + result.error);
     }


### PR DESCRIPTION
when creating secrets, --replication-policy flag is required. 
error:
Exception in thread "main" java.lang.Error: failed to create secret, secret=ub-dev-db-data-warehouse-root-password, error=ERROR: (gcloud.secrets.create) Missing required argument [replication-policy]: The --replication-policy flag is required. Valid values are "automatic" and "user-managed".

	at core.infra.gcloud.SecretClient.createSecret(SecretClient.java:30)
	at core.infra.gcloud.SecretClient.getOrCreateSecret(SecretClient.java:21)
	at core.infra.command.SyncDBCommand.sync(SyncDBCommand.java:36)
	at core.infra.ui.Console.syncDB(Console.java:51)
	at core.infra.ui.Console.execute(Console.java:38)
	at Main.main(Main.java:8)